### PR TITLE
Add ability to read contents and direct fetch from main

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -5,16 +5,18 @@ on:
     types: [opened, synchronize]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:
   review:
+    name: Review
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Code Review
-        uses: tarmojussila/zai-code-review@v1
+        uses: tarmojussila/zai-code-review@main
         with:
           ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
           ZAI_MODEL: ${{ vars.ZAI_MODEL }}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: tarmojussila/zai-code-review@v1
+      - uses: tarmojussila/zai-code-review@main
         with:
           api_key: ${{ secrets.ZAI_API_KEY }}
 ```


### PR DESCRIPTION
This pull request updates the configuration for the AI code review GitHub Action, focusing on improving permissions and ensuring the workflow uses the latest version of the action. The most important changes are:

**GitHub Actions configuration updates:**

* Changed the `zai-code-review` action version from `@v1` to `@main` in both `.github/workflows/ai-review.yml` and the usage example in `README.md`, ensuring the workflow uses the latest code from the action.

**Permissions improvements:**

* Added explicit `contents: read` permission to the workflow permissions block in `.github/workflows/ai-review.yml` to clarify and potentially improve security.

**Workflow metadata:**

* Added a `name: Review` field to the `review` job for clearer identification in the workflow run interface.