### PR TITLE
Fix README: correct input name and add permissions block

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   review:
     runs-on: ubuntu-latest
@@ -27,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: tarmojussila/zai-code-review@main
         with:
-          api_key: ${{ secrets.ZAI_API_KEY }}
+          ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
 ```
 
 ## Configuration


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration in `README.md` by adding explicit permissions and correcting the usage of a secret in the workflow.

* GitHub Actions permissions: Added `contents: read` and `pull-requests: write` permissions to the workflow configuration.
* Workflow secret usage: Changed the secret input from `api_key` to `ZAI_API_KEY` for the `zai-code-review` action.