### PR TITLE
Add inputs table and fix input name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ jobs:
           ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
 ```
 
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `ZAI_API_KEY` | Yes | — | Your Z.ai API key |
+| `ZAI_MODEL` | No | `glm-4.7` | Z.ai model to use for review |
+
 ## Configuration
 
 To use this action, you must add your Z.ai API key as a GitHub secret.


### PR DESCRIPTION
This pull request adds documentation for the available input parameters for the GitHub Action in the `README.md`. It introduces a new section that clearly lists and describes the required and optional inputs, making it easier for users to configure the action.

Documentation improvements:

* Added an "Inputs" section to `README.md` that documents the `ZAI_API_KEY` (required) and `ZAI_MODEL` (optional, defaulting to `glm-4.7`) parameters, including their descriptions and requirements.