### PR TITLE
Add null check for Z.ai API response choices

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -31893,7 +31893,12 @@ function callZaiApi(apiKey, model, prompt) {
       res.on('end', () => {
         if (res.statusCode >= 200 && res.statusCode < 300) {
           const parsed = JSON.parse(data);
-          resolve(parsed.choices[0].message.content);
+          const content = parsed.choices?.[0]?.message?.content;
+          if (!content) {
+            reject(new Error(`Z.ai API returned an empty response: ${data}`));
+          } else {
+            resolve(content);
+          }
         } else {
           reject(new Error(`Z.ai API error ${res.statusCode}: ${data}`));
         }

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,12 @@ function callZaiApi(apiKey, model, prompt) {
       res.on('end', () => {
         if (res.statusCode >= 200 && res.statusCode < 300) {
           const parsed = JSON.parse(data);
-          resolve(parsed.choices[0].message.content);
+          const content = parsed.choices?.[0]?.message?.content;
+          if (!content) {
+            reject(new Error(`Z.ai API returned an empty response: ${data}`));
+          } else {
+            resolve(content);
+          }
         } else {
           reject(new Error(`Z.ai API error ${res.statusCode}: ${data}`));
         }


### PR DESCRIPTION
Prevents crash when API returns empty or malformed choices array.