### PR TITLE
Remove invalid expression default from GITHUB_TOKEN input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,6 @@ inputs:
   GITHUB_TOKEN:
     description: "GitHub token for API access"
     required: false
-    default: ${{ github.token }}
 runs:
   using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION
Expressions like ${{ github.token }} are not evaluated in action.yml inputs. The token is already available via process.env.GITHUB_TOKEN in the action code as a fallback.