### PR TITLE
Update version to 0.1.1

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Code Review
-        uses: tarmojussila/zai-code-review@bugfix/github-token-handling
+        uses: tarmojussila/zai-code-review@v0.1.1
         with:
           ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
           ZAI_MODEL: ${{ vars.ZAI_MODEL }}

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Code Review
-        uses: tarmojussila/zai-code-review@main
+        uses: tarmojussila/zai-code-review@v0.1.1
         with:
           ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zai-code-review",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "AI-powered code review GitHub Action using Z.ai",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
This pull request updates the GitHub Action and documentation to use the latest released version of the `zai-code-review` action, ensuring consistency across the workflow and README. It also bumps the package version to reflect the new release.

Version updates:

* Updated the `zai-code-review` action reference in `.github/workflows/code-review.yml` from a branch name to the tagged release `v0.1.1`.
* Updated the `zai-code-review` action reference in `README.md` from `main` to `v0.1.1` for clarity and stability.
* Bumped the package version in `package.json` from `0.1.0` to `0.1.1` to match the latest release.