### PR TITLE
Adjustable code reviewer name

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Review
-        uses: tarmojussila/zai-code-review@v0.2.0
+        uses: tarmojussila/zai-code-review@feature/adjustable-code-reviewer-name
         with:
           ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
           ZAI_MODEL: ${{ vars.ZAI_MODEL }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -19,3 +19,4 @@ jobs:
           ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
           ZAI_MODEL: ${{ vars.ZAI_MODEL }}
           ZAI_SYSTEM_PROMPT: ${{ vars.ZAI_SYSTEM_PROMPT }}
+          ZAI_REVIEWER_NAME: ${{ vars.ZAI_REVIEWER_NAME }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -13,8 +13,6 @@ jobs:
     name: Review
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: Code Review
         uses: tarmojussila/zai-code-review@v0.2.0
         with:

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Review
-        uses: tarmojussila/zai-code-review@feature/adjustable-code-reviewer-name
+        uses: tarmojussila/zai-code-review@v0.2.0
         with:
           ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
           ZAI_MODEL: ${{ vars.ZAI_MODEL }}

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Generate an API key from your Z.ai dashboard.
 
 ## Advanced configuration
 
-Instead of using default values for `ZAI_MODEL` and `ZAI_SYSTEM_PROMPT`, you can override them, and manage them as GitHub Actions variables. This lets you update the model or review prompt without touching the workflow file.
+Instead of using default values for `ZAI_MODEL`, `ZAI_SYSTEM_PROMPT`, and `ZAI_REVIEWER_NAME`, you can override them, and manage them as GitHub Actions variables. This lets you update the model, review prompt, or reviewer name without touching the workflow file.
 
 ### 1️⃣ Add the variables to your repository
 
@@ -83,6 +83,7 @@ Instead of using default values for `ZAI_MODEL` and `ZAI_SYSTEM_PROMPT`, you can
 
    - **Name:** `ZAI_MODEL` — **Value:** e.g. `glm-4.7`
    - **Name:** `ZAI_SYSTEM_PROMPT` — **Value:** your custom system prompt
+   - **Name:** `ZAI_REVIEWER_NAME` — **Value:** e.g. `AI Code Review`
 
 ### 2️⃣ Reference them in your workflow
 
@@ -93,6 +94,7 @@ Instead of using default values for `ZAI_MODEL` and `ZAI_SYSTEM_PROMPT`, you can
           ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
           ZAI_MODEL: ${{ vars.ZAI_MODEL }}
           ZAI_SYSTEM_PROMPT: ${{ vars.ZAI_SYSTEM_PROMPT }}
+          ZAI_REVIEWER_NAME: ${{ vars.ZAI_REVIEWER_NAME }}
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ jobs:
 | `ZAI_API_KEY` | Yes | — | Your Z.ai API key |
 | `ZAI_MODEL` | No | `glm-4.7` | Z.ai model to use for review |
 | `ZAI_SYSTEM_PROMPT` | No | See below | Custom system prompt for the AI reviewer |
+| `ZAI_REVIEWER_NAME` | No | `Z.ai Code Review` | Name shown in the review comment header |
 
 The default system prompt is:
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ jobs:
     name: Review
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: Code Review
         uses: tarmojussila/zai-code-review@v0.2.0
         with:

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: "Custom system prompt for the AI reviewer"
     required: false
     default: "You are an expert code reviewer. Review the provided code changes and give clear, actionable feedback."
+  ZAI_REVIEWER_NAME:
+    description: "Name shown in the review comment header"
+    required: false
+    default: "Z.ai Code Review"
   GITHUB_TOKEN:
     description: "GitHub token for API access"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -31917,6 +31917,7 @@ async function run() {
   core.setSecret(apiKey);
   const model = core.getInput('ZAI_MODEL') || 'glm-4.7';
   const systemPrompt = core.getInput('ZAI_SYSTEM_PROMPT') || 'You are an expert code reviewer. Review the provided code changes and give clear, actionable feedback.';
+  const reviewerName = core.getInput('ZAI_REVIEWER_NAME') || 'Z.ai Code Review';
   const token = core.getInput('GITHUB_TOKEN') || process.env.GITHUB_TOKEN;
 
   const { context } = github;
@@ -31942,7 +31943,7 @@ async function run() {
 
   core.info(`Sending ${files.length} file(s) to Z.ai for review...`);
   const review = await callZaiApi(apiKey, model, systemPrompt, prompt);
-  const body = `## Z.ai Code Review\n\n${review}\n\n${COMMENT_MARKER}`;
+  const body = `## ${reviewerName}\n\n${review}\n\n${COMMENT_MARKER}`;
 
   const { data: comments } = await octokit.rest.issues.listComments({
     owner,

--- a/dist/index.js
+++ b/dist/index.js
@@ -31915,9 +31915,9 @@ function callZaiApi(apiKey, model, systemPrompt, prompt) {
 async function run() {
   const apiKey = core.getInput('ZAI_API_KEY', { required: true });
   core.setSecret(apiKey);
-  const model = core.getInput('ZAI_MODEL') || 'glm-4.7';
-  const systemPrompt = core.getInput('ZAI_SYSTEM_PROMPT') || 'You are an expert code reviewer. Review the provided code changes and give clear, actionable feedback.';
-  const reviewerName = core.getInput('ZAI_REVIEWER_NAME') || 'Z.ai Code Review';
+  const model = core.getInput('ZAI_MODEL');
+  const systemPrompt = core.getInput('ZAI_SYSTEM_PROMPT');
+  const reviewerName = core.getInput('ZAI_REVIEWER_NAME');
   const token = core.getInput('GITHUB_TOKEN') || process.env.GITHUB_TOKEN;
 
   const { context } = github;

--- a/dist/index.js
+++ b/dist/index.js
@@ -31918,7 +31918,8 @@ async function run() {
   const model = core.getInput('ZAI_MODEL');
   const systemPrompt = core.getInput('ZAI_SYSTEM_PROMPT');
   const reviewerName = core.getInput('ZAI_REVIEWER_NAME');
-  const token = core.getInput('GITHUB_TOKEN') || process.env.GITHUB_TOKEN;
+  const token = core.getInput('GITHUB_TOKEN');
+  core.setSecret(token);
 
   const { context } = github;
   const { owner, repo } = context.repo;

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,7 @@ async function run() {
   core.setSecret(apiKey);
   const model = core.getInput('ZAI_MODEL') || 'glm-4.7';
   const systemPrompt = core.getInput('ZAI_SYSTEM_PROMPT') || 'You are an expert code reviewer. Review the provided code changes and give clear, actionable feedback.';
+  const reviewerName = core.getInput('ZAI_REVIEWER_NAME') || 'Z.ai Code Review';
   const token = core.getInput('GITHUB_TOKEN') || process.env.GITHUB_TOKEN;
 
   const { context } = github;
@@ -106,7 +107,7 @@ async function run() {
 
   core.info(`Sending ${files.length} file(s) to Z.ai for review...`);
   const review = await callZaiApi(apiKey, model, systemPrompt, prompt);
-  const body = `## Z.ai Code Review\n\n${review}\n\n${COMMENT_MARKER}`;
+  const body = `## ${reviewerName}\n\n${review}\n\n${COMMENT_MARKER}`;
 
   const { data: comments } = await octokit.rest.issues.listComments({
     owner,

--- a/src/index.js
+++ b/src/index.js
@@ -79,9 +79,9 @@ function callZaiApi(apiKey, model, systemPrompt, prompt) {
 async function run() {
   const apiKey = core.getInput('ZAI_API_KEY', { required: true });
   core.setSecret(apiKey);
-  const model = core.getInput('ZAI_MODEL') || 'glm-4.7';
-  const systemPrompt = core.getInput('ZAI_SYSTEM_PROMPT') || 'You are an expert code reviewer. Review the provided code changes and give clear, actionable feedback.';
-  const reviewerName = core.getInput('ZAI_REVIEWER_NAME') || 'Z.ai Code Review';
+  const model = core.getInput('ZAI_MODEL');
+  const systemPrompt = core.getInput('ZAI_SYSTEM_PROMPT');
+  const reviewerName = core.getInput('ZAI_REVIEWER_NAME');
   const token = core.getInput('GITHUB_TOKEN') || process.env.GITHUB_TOKEN;
 
   const { context } = github;

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,8 @@ async function run() {
   const model = core.getInput('ZAI_MODEL');
   const systemPrompt = core.getInput('ZAI_SYSTEM_PROMPT');
   const reviewerName = core.getInput('ZAI_REVIEWER_NAME');
-  const token = core.getInput('GITHUB_TOKEN') || process.env.GITHUB_TOKEN;
+  const token = core.getInput('GITHUB_TOKEN');
+  core.setSecret(token);
 
   const { context } = github;
   const { owner, repo } = context.repo;


### PR DESCRIPTION
This pull request introduces support for customizing the reviewer name displayed in code review comments generated by the Z.ai GitHub Action. It adds a new optional input, `ZAI_REVIEWER_NAME`, allowing users to specify a custom name for the reviewer in workflow configuration, documentation, and the action implementation. The README and workflow examples are updated to reflect this new feature.

**Customizable Reviewer Name Feature:**

* Added a new input `ZAI_REVIEWER_NAME` to `action.yml`, allowing users to set a custom reviewer name for the comment header, with a default of "Z.ai Code Review".
* Updated `src/index.js` to read the `ZAI_REVIEWER_NAME` input and use it dynamically in the review comment header instead of the hardcoded value.

**Workflow and Documentation Updates:**

* Modified `.github/workflows/code-review.yml` to use the new reviewer name input and updated the action reference to a feature branch supporting this option.
* Updated `README.md` to document the new `ZAI_REVIEWER_NAME` input, including its usage, default value, and instructions for advanced configuration using GitHub Actions variables.
* Removed the unnecessary checkout step from workflow and documentation examples, streamlining the setup process.